### PR TITLE
fix(git): detach git-sync and throttle hook execution

### DIFF
--- a/dot_config/git/hooks/executable_post-checkout
+++ b/dot_config/git/hooks/executable_post-checkout
@@ -34,4 +34,8 @@ fi
 
 GITSYNC=$(command -v git-sync || true)
 [[ -z "$GITSYNC" && -x "$HOME/.local/bin/git-sync" ]] && GITSYNC="$HOME/.local/bin/git-sync"
-[[ -n "$GITSYNC" ]] && "$GITSYNC"
+# Detach so GUI clients (GitKraken) don't block on the fetch+trim run.
+if [[ -n "$GITSYNC" ]]; then
+  nohup "$GITSYNC" </dev/null >/dev/null 2>&1 &
+  disown 2>/dev/null || true
+fi

--- a/dot_local/bin/executable_git-sync
+++ b/dot_local/bin/executable_git-sync
@@ -5,7 +5,27 @@
 
 set -euo pipefail
 
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null) || exit 0
+[[ "$GIT_DIR" != /* ]] && GIT_DIR="$(pwd)/$GIT_DIR"
+
+# Non-TTY (e.g. GitKraken hook) flags any stdout/stderr as a hook error popup.
+# Redirect to a log file when not attached to a terminal, and throttle
+# hook-driven runs so rapid branch switches don't re-fetch every time.
+if [[ ! -t 1 ]]; then
+  exec >>"$HOME/.cache/git-sync.log" 2>&1
+  if [[ -f "$GIT_DIR/FETCH_HEAD" ]] \
+    && [[ -n "$(find "$GIT_DIR/FETCH_HEAD" -mmin -5 -print 2>/dev/null)" ]]; then
+    exit 0
+  fi
+fi
+
 CURRENT=$(git branch --show-current)
+
+# Capture default-branch SHA pre-fetch — git-trim is skipped unless it advances
+# (no merge upstream ⇒ nothing to prune locally).
+DEFAULT_REF=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)
+PRE_DEFAULT_SHA=""
+[[ -n "$DEFAULT_REF" ]] && PRE_DEFAULT_SHA=$(git rev-parse --quiet --verify "$DEFAULT_REF" 2>/dev/null || true)
 
 do-ff() {
   local INPUT_REMOTE="${1}"
@@ -52,6 +72,10 @@ if [ -n "${CURRENT}" ]; then
 fi
 
 if command -v git-trim >/dev/null 2>&1; then
-  echo "git trim"
-  git trim --no-update --no-confirm
+  POST_DEFAULT_SHA=""
+  [[ -n "$DEFAULT_REF" ]] && POST_DEFAULT_SHA=$(git rev-parse --quiet --verify "$DEFAULT_REF" 2>/dev/null || true)
+  if [[ "$PRE_DEFAULT_SHA" != "$POST_DEFAULT_SHA" ]]; then
+    echo "git trim"
+    git trim --no-update --no-confirm
+  fi
 fi

--- a/dot_local/bin/executable_git-sync
+++ b/dot_local/bin/executable_git-sync
@@ -12,6 +12,7 @@ GIT_DIR=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 # Redirect to a log file when not attached to a terminal, and throttle
 # hook-driven runs so rapid branch switches don't re-fetch every time.
 if [[ ! -t 1 ]]; then
+  mkdir -p "$HOME/.cache"
   exec >>"$HOME/.cache/git-sync.log" 2>&1
   if [[ -f "$GIT_DIR/FETCH_HEAD" ]] \
     && [[ -n "$(find "$GIT_DIR/FETCH_HEAD" -mmin -5 -print 2>/dev/null)" ]]; then
@@ -74,7 +75,7 @@ fi
 if command -v git-trim >/dev/null 2>&1; then
   POST_DEFAULT_SHA=""
   [[ -n "$DEFAULT_REF" ]] && POST_DEFAULT_SHA=$(git rev-parse --quiet --verify "$DEFAULT_REF" 2>/dev/null || true)
-  if [[ "$PRE_DEFAULT_SHA" != "$POST_DEFAULT_SHA" ]]; then
+  if [[ -z "$DEFAULT_REF" || "$PRE_DEFAULT_SHA" != "$POST_DEFAULT_SHA" ]]; then
     echo "git trim"
     git trim --no-update --no-confirm
   fi


### PR DESCRIPTION
Updated the post-checkout hook and git-sync script to prevent GUI clients from blocking and to reduce redundant network operations during rapid branch switching.

- Modified executable_post-checkout to run git-sync in the background using nohup and disown to prevent GitKraken from hanging.
- Added a 5-minute throttle to executable_git-sync based on FETCH_HEAD modification time to skip unnecessary fetches.
- Implemented logging to ~/.cache/git-sync.log for non-interactive shell sessions.
- Added a SHA comparison check for the default branch to ensure git-trim only runs when upstream changes are detected.