### PR TITLE
fix(git-sync): always run git-trim, drop default-ref-advance guard

### DIFF
--- a/dot_local/bin/executable_git-sync
+++ b/dot_local/bin/executable_git-sync
@@ -16,12 +16,6 @@ fi
 
 CURRENT=$(git branch --show-current)
 
-# Capture default-branch SHA pre-fetch — git-trim is skipped unless it advances
-# (no merge upstream ⇒ nothing to prune locally).
-DEFAULT_REF=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)
-PRE_DEFAULT_SHA=""
-[[ -n "$DEFAULT_REF" ]] && PRE_DEFAULT_SHA=$(git rev-parse --quiet --verify "$DEFAULT_REF" 2>/dev/null || true)
-
 do-ff() {
   local INPUT_REMOTE="${1}"
   local LOCAL REMOTE UPSTREAM
@@ -67,10 +61,6 @@ if [ -n "${CURRENT}" ]; then
 fi
 
 if command -v git-trim >/dev/null 2>&1; then
-  POST_DEFAULT_SHA=""
-  [[ -n "$DEFAULT_REF" ]] && POST_DEFAULT_SHA=$(git rev-parse --quiet --verify "$DEFAULT_REF" 2>/dev/null || true)
-  if [[ -z "$DEFAULT_REF" || "$PRE_DEFAULT_SHA" != "$POST_DEFAULT_SHA" ]]; then
-    echo "git trim"
-    git trim --no-update --no-confirm --delete 'merged:origin,local'
-  fi
+  echo "git trim"
+  git trim --no-update --no-confirm --delete 'merged:origin,local'
 fi


### PR DESCRIPTION
## Summary
- Previous guard `[[ -z "$DEFAULT_REF" || "$PRE_DEFAULT_SHA" != "$POST_DEFAULT_SHA" ]]` only ran trim when default branch advanced. That misses pre-existing merged untracked branches (e.g. squash-merged before `git-trim` was wired up, or branches whose merge happened in a prior fetch round).
- Trim is idempotent and fast — drop the guard, always run it.

## Test plan
- [x] Direct run on `~/Code/mayurifag.ru`: `dns` (non-tracking, merged into main) deleted; unmerged `glances`/`https-proxy`/`ufw` retained.