### PR TITLE
fix(git): post-checkout hook exit code on empty chain

### DIFF
--- a/dot_config/git/hooks/executable_post-checkout
+++ b/dot_config/git/hooks/executable_post-checkout
@@ -7,19 +7,31 @@ echo "$(date '+%FT%T%z') pid=$$ ppid=$PPID parent=$(ps -o comm= -p $PPID 2>/dev/
 set -euo pipefail
 
 ORIG_ARGS=("$@")
+HOOKS_DIR=$(cd "$(dirname "$0")" && pwd)
 
 run_chain() {
-  local hook_name self top_dir git_dir candidate
+  local rc=0 hook_name self top_dir git_dir candidate
   hook_name=$(basename "$0")
-  self=$(cd "$(dirname "$0")" && pwd)/$hook_name
+  self="$HOOKS_DIR/$hook_name"
   top_dir=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
   git_dir=$(git rev-parse --git-dir 2>/dev/null) || return 0
   [[ "$git_dir" != /* ]] && git_dir="$top_dir/$git_dir"
   for candidate in "$top_dir/.githooks/$hook_name" "$git_dir/hooks/$hook_name"; do
-    [[ -x "$candidate" && "$candidate" != "$self" ]] && "$candidate" "${ORIG_ARGS[@]}"
+    if [[ -x "$candidate" && "$candidate" != "$self" ]]; then
+      "$candidate" ${ORIG_ARGS[@]+"${ORIG_ARGS[@]}"} || rc=$?
+    fi
   done
+  return $rc
 }
-trap 'run_chain' EXIT
+
+cleanup() {
+  local rc=$?
+  local chain_rc=0
+  run_chain || chain_rc=$?
+  (( chain_rc != 0 && rc == 0 )) && rc=$chain_rc
+  exit "$rc"
+}
+trap cleanup EXIT
 
 [[ "${3:-0}" != "1" ]] && exit 0
 [[ "${1:-}" == "0000000000000000000000000000000000000000" ]] && exit 0


### PR DESCRIPTION
## Summary

- `run_chain` in `post-checkout` returned 1 when no chained hook existed, because `[[ -x ... && ... ]] && cmd` short-circuits to false. The EXIT trap re-raised that nonzero status, so GUIs like GitKraken surfaced "checkout failed exit 1" even though the checkout + git-sync + git-trim worked.
- Aligned with the `pre-commit` / `pre-push` pattern: explicit `if`-block, `|| rc=$?`, `cleanup` trap that preserves the script's original rc and only promotes chain rc when the script itself succeeded.

## Test plan

- [x] `git switch -c tmp` then `git switch master` returns rc=0 (was 1)
- [x] git-sync + git-trim still fire on returning to default branch
- [ ] GitKraken checkout to default branch no longer shows "exit 1" error