### PR TITLE
perf(git): detach git-sync so GUI hooks return fast

### DIFF
--- a/dot_config/git/hooks/executable_post-checkout
+++ b/dot_config/git/hooks/executable_post-checkout
@@ -48,4 +48,8 @@ fi
 
 GITSYNC=$(command -v git-sync || true)
 [[ -z "$GITSYNC" && -x "$HOME/.local/bin/git-sync" ]] && GITSYNC="$HOME/.local/bin/git-sync"
-[[ -n "$GITSYNC" ]] && "$GITSYNC" </dev/null
+if [[ -n "$GITSYNC" ]]; then
+  log="$HOME/.cache/git-sync.log"
+  mkdir -p "$HOME/.cache" 2>/dev/null || true
+  ( "$GITSYNC" </dev/null >>"$log" 2>&1 & ) </dev/null >/dev/null 2>&1
+fi


### PR DESCRIPTION
## Summary

- Hook was running `git-sync` synchronously, so GUIs (GitKraken) blocked for seconds after each checkout to default branch.
- Now spawn `git-sync` as a detached background child. Hook returns in ~tens of ms.
- All stdio redirected to `~/.cache/git-sync.log` for inspection.
- Pattern works cross-platform (macOS / Linux / Git Bash on Windows) without `setsid`/`nohup`: `( cmd </dev/null >>log 2>&1 & ) </dev/null >/dev/null 2>&1` — the subshell exits as soon as it backgrounds the child, breaking the parent's wait chain.

## Test plan

- [x] `git switch -c tmp && git switch master` returns rc=0 in ~63ms (was multi-second)
- [x] Background `git-sync` still completes fetch + trim, output captured in `~/.cache/git-sync.log`
- [ ] GitKraken checkout to default branch returns instantly, branches still trimmed